### PR TITLE
Add node package.json and configuration fields to plugin.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+	"name": "graphdat-httpcheck-plugin",
+	"version": "0.0.1",
+	"private": false,
+	"description": "HTTP Check plugin for Graphat to poll a URL and report back its response time",
+	"main": "index.js",
+	"devDependencies": {},
+	"dependencies": {
+		"async": "0.2.x",
+		"graphdat-plugin-tools" : "0.0.1",
+		"request" : "2.27.x",
+		"underscore": "1.5.x"
+	},
+	"repository": {
+	"type": "git",
+	"url": "https://github.com/graphdat/plugin-httpcheck"
+	},
+	"keywords": [
+		"graphdat",
+		"plugin",
+		"http",
+		"response",
+		"poll"
+	],
+	"author": "Graphdat <support@graphdat.com>",
+	"license": "Apache v2",
+	"bugs": {
+		"url": "https://github.com/graphdat/plugin-httpcheck/issues"
+	},
+	"engine": "node >= 0.8.1"
+}

--- a/plugin.json
+++ b/plugin.json
@@ -1,5 +1,37 @@
 {
  "description" : "Provides Wowza Connection Stats",
  "command" : "./wowzapoll.sh",
- "metrics" : ["WOWZA_CONNECTIONS_CURRENT", "WOWZA_CONNECTIONS_TOTAL", "WOWZA_CONNECTIONS_BYTES_IN", "WOWZA_CONNECTIONS_BYTES_OUT"]
+ "metrics" : ["WOWZA_CONNECTIONS_CURRENT", "WOWZA_CONNECTIONS_TOTAL", "WOWZA_CONNECTIONS_BYTES_IN", "WOWZA_CONNECTIONS_BYTES_OUT"],
+
+ "postExtract" : "npm install",
+ "ignore" : "node_modules",
+
+ "paramArray": { "itemTitle": [ "source" ], "schemaTitle": "Example multiple connection configuration" },
+ "paramSchema": [
+        {
+            "title": "Source",
+            "name": "string",
+            "description": "Source to use for this connection. Defaults to the local hostname",
+            "type": "string",
+            "default": "hello",
+            "required": true
+        },
+        {
+            "title": "User",
+            "name": "string",
+            "description": "User name to use to authenticate",
+            "type": "string",
+            "default": "joe",
+            "required": true
+        },
+        {
+            "title" : "Password",
+            "name" : "password",
+            "description" : "Password to use to authenticate",
+            "type" : "password",
+            "required": true
+        }
+ ]
+
+
 }


### PR DESCRIPTION
- Example package.json that is used for declaring dependencies for a nodeJS application
- Updated plugin.json with postExtract and ignore fields. The previous is called after the plugin is installed which add the dependent nodeJS modules from the package.json file. The ignore field specifies the node_module directory should be ignored. (The plugin manager keeps check sums of files in a plugin to know if it should be updated, the ignore field, designates directories that should be ignored in determining if a plugin has changed.
- paramArray and paramSchema provide configuration fields for a plugin, the fields appear in the user Plugin Configuration dialog